### PR TITLE
feature-ui: 카드에 이미지 transition, shadow, text color 변경 처리 추가(#7)

### DIFF
--- a/src/components/BlogPostCardPreview.astro
+++ b/src/components/BlogPostCardPreview.astro
@@ -5,12 +5,12 @@ export interface Props {
 
 const { post } = Astro.props;
 ---
-<div class="w-card">
+<div class="w-card group">
   <article class="w-card-base w-card-base__with--cover">
-    <div class="w-card-base__cover">
+    <div class="w-card-base__cover transform group-hover:-translate-y-1 transition duration-300 ease-in-out shadow-lg group-hover:shadow-2xl">
       <a href={post.url} class="w-card-base__link">
         <figure class="w-card-base__figure aspect-w-4 aspect-h-3">
-          <img src={post.heroImage} alt={post.alt} class="w-full rounded-xl shadow-lg object-cover object-center">
+          <img src={post.heroImage} alt={post.alt} class="w-full rounded-xl  object-cover object-center">
         </figure>
       </a>
     </div>
@@ -19,7 +19,7 @@ const { post } = Astro.props;
         <h2 class="text-lg leading-6 mt-2 font-medium text-gray-500">{post.type}</h2>
       </a>
       <a href={post.url} class="">
-        <h2 class="text-2xl font-semibold mt-2">{post.title}</h2>
+        <h2 class="text-2xl font-semibold mt-2 transform group-hover:text-blue-500 transition-colors duration-300 ease-in-out">{post.title}</h2>
       </a>
       <div class="text-gray-500 mt-2">
         <time>{post.publishDate}</time>


### PR DESCRIPTION
Fixes #7

Changes proposed in this pull request:

카드에 토스 블로그와 같이 Hover 이펙트들을 추가했다.
이미지를 엘리베이션 하면서 그림자를 더 짙게 표현하였다.
제목은 색을 변경하여 옆에 있는 카드들과 차이를 두었다.

- Tailwind에 있는 Transition을 활용하여 부드럽게 표현했고 카드 안에 여러 자식 태그들에 개별적으로 적용하기 위해 group 기능을 사용하였다.
